### PR TITLE
Improve speed using &str over String

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ impl Stava {
         }
 
         let mut candidates: HashMap<u32, String> = HashMap::new();
-        let edits = self.get_edits(word.to_string());
+        let edits = self.get_edits(word);
 
         // Add edited words as candidates
         for edit in &edits {
@@ -70,7 +70,7 @@ impl Stava {
 
         // Add additional edits based on first edited words
         for edit in &edits {
-            for word in self.get_edits(edit.to_string()) {
+            for word in self.get_edits(edit) {
                 if let Some(count) = self.words_w_count.get(&word) {
                     candidates.insert(*count, word);
                 }
@@ -92,50 +92,50 @@ impl Stava {
         }
     }
 
-    fn get_edits(&self, word: String) -> HashSet<String> {
+    fn get_edits(&self, word: &str) -> HashSet<String> {
         let splits = self.splits(word);
         HashSet::from_iter(
             [
-                self.deletes(splits.clone()),
-                self.transposes(splits.clone()),
-                self.replaces(splits.clone()),
-                self.inserts(splits),
+                self.deletes(&splits),
+                self.transposes(&splits),
+                self.replaces(&splits),
+                self.inserts(&splits),
             ]
             .concat(),
         )
     }
 
-    fn splits(&self, word: String) -> Vec<(String, String)> {
-        let mut result = Vec::with_capacity(word.len() + 1);
+    fn splits<'a>(&self, word: &'a str) -> Vec<(&'a str, &'a str)> {
+        let mut result: Vec<(&str, &str)> = Vec::with_capacity(word.len() + 1);
         let range = 0..result.capacity();
         for i in range {
-            let left = String::from(&word[..i]);
-            let right = String::from(&word[i..]);
+            let left = &word[..i];
+            let right = &word[i..];
             result.push((left, right));
         }
         result
     }
 
-    fn deletes(&self, words: Vec<(String, String)>) -> Vec<String> {
+    fn deletes(&self, words: &[(&str, &str)]) -> Vec<String> {
         let mut result = Vec::with_capacity(words.len() - 1);
         for (left, right) in words {
             if !right.is_empty() {
-                result.push([left.to_owned(), right[1..].to_string()].concat());
+                result.push([left, &right[1..]].concat());
             }
         }
         result
     }
 
-    fn transposes(&self, words: Vec<(String, String)>) -> Vec<String> {
+    fn transposes(&self, words: &[(&str, &str)]) -> Vec<String> {
         let mut result = Vec::with_capacity(words.len() - 2);
         for (left, right) in words {
             if right.len() > 1 {
                 result.push(
                     [
                         left.to_owned(),
-                        right.chars().nth(1).unwrap().to_string(),
-                        right.chars().next().unwrap().to_string(),
-                        right[2..].to_string(),
+                        right.chars().nth(1).unwrap().to_string().as_str(),
+                        right.chars().next().unwrap().to_string().as_str(),
+                        &right[2..],
                     ]
                     .concat(),
                 );
@@ -144,30 +144,23 @@ impl Stava {
         result
     }
 
-    fn replaces(&self, words: Vec<(String, String)>) -> Vec<String> {
+    fn replaces(&self, words: &[(&str, &str)]) -> Vec<String> {
         let mut result = Vec::new();
         for (left, right) in words {
             if !right.is_empty() {
                 for letter in ENG_ALPHABET.iter() {
-                    result.push(
-                        [
-                            left.to_owned(),
-                            (*letter).to_string(),
-                            right[1..].to_string(),
-                        ]
-                        .concat(),
-                    );
+                    result.push([left.to_owned(), (*letter), &right[1..]].concat());
                 }
             }
         }
         result
     }
 
-    fn inserts(&self, words: Vec<(String, String)>) -> Vec<String> {
+    fn inserts(&self, words: &[(&str, &str)]) -> Vec<String> {
         let mut result = Vec::new();
         for (left, right) in words {
             for letter in ENG_ALPHABET.iter() {
-                result.push([left.to_owned(), (*letter).to_string(), right.to_string()].concat());
+                result.push([left, (*letter), right].concat());
             }
         }
         result
@@ -183,15 +176,15 @@ mod tests {
         let stava = Stava {
             words_w_count: HashMap::new(),
         };
-        let actual = stava.splits(String::from("monkey"));
-        let expected: Vec<(String, String)> = vec![
-            (String::from(""), String::from("monkey")),
-            (String::from("m"), String::from("onkey")),
-            (String::from("mo"), String::from("nkey")),
-            (String::from("mon"), String::from("key")),
-            (String::from("monk"), String::from("ey")),
-            (String::from("monke"), String::from("y")),
-            (String::from("monkey"), String::from("")),
+        let actual = stava.splits("monkey");
+        let expected = vec![
+            ("", "monkey"),
+            ("m", "onkey"),
+            ("mo", "nkey"),
+            ("mon", "key"),
+            ("monk", "ey"),
+            ("monke", "y"),
+            ("monkey", ""),
         ];
         assert_eq!(actual, expected);
     }
@@ -201,24 +194,17 @@ mod tests {
         let stava = Stava {
             words_w_count: HashMap::new(),
         };
-        let splits: Vec<(String, String)> = vec![
-            (String::from(""), String::from("monkey")),
-            (String::from("m"), String::from("onkey")),
-            (String::from("mo"), String::from("nkey")),
-            (String::from("mon"), String::from("key")),
-            (String::from("monk"), String::from("ey")),
-            (String::from("monke"), String::from("y")),
-            (String::from("monkey"), String::from("")),
+        let splits = vec![
+            ("", "monkey"),
+            ("m", "onkey"),
+            ("mo", "nkey"),
+            ("mon", "key"),
+            ("monk", "ey"),
+            ("monke", "y"),
+            ("monkey", ""),
         ];
-        let actual = stava.deletes(splits);
-        let expected: Vec<String> = vec![
-            String::from("onkey"),
-            String::from("mnkey"),
-            String::from("mokey"),
-            String::from("money"),
-            String::from("monky"),
-            String::from("monke"),
-        ];
+        let actual = stava.deletes(&*splits);
+        let expected = vec!["onkey", "mnkey", "mokey", "money", "monky", "monke"];
         assert_eq!(actual, expected);
     }
 
@@ -227,20 +213,17 @@ mod tests {
         let stava = Stava {
             words_w_count: HashMap::new(),
         };
-        let splits: Vec<(String, String)> = vec![
-            (String::from(""), String::from("monkey")),
-            (String::from("m"), String::from("onkey")),
-            (String::from("mo"), String::from("nkey")),
-            (String::from("mon"), String::from("key")),
-            (String::from("monk"), String::from("ey")),
-            (String::from("monke"), String::from("y")),
-            (String::from("monkey"), String::from("")),
+        let splits = vec![
+            ("", "monkey"),
+            ("m", "onkey"),
+            ("mo", "nkey"),
+            ("mon", "key"),
+            ("monk", "ey"),
+            ("monke", "y"),
+            ("monkey", ""),
         ];
-        let actual = stava.transposes(splits);
-        let expected: Vec<String> = vec!["omnkey", "mnokey", "mokney", "moneky", "monkye"]
-            .into_iter()
-            .map(String::from)
-            .collect();
+        let actual = stava.transposes(&*splits);
+        let expected = vec!["omnkey", "mnokey", "mokney", "moneky", "monkye"];
         assert_eq!(actual, expected);
     }
 
@@ -249,17 +232,17 @@ mod tests {
         let stava = Stava {
             words_w_count: HashMap::new(),
         };
-        let splits: Vec<(String, String)> = vec![
-            (String::from(""), String::from("monkey")),
-            (String::from("m"), String::from("onkey")),
-            (String::from("mo"), String::from("nkey")),
-            (String::from("mon"), String::from("key")),
-            (String::from("monk"), String::from("ey")),
-            (String::from("monke"), String::from("y")),
-            (String::from("monkey"), String::from("")),
+        let splits = vec![
+            ("", "monkey"),
+            ("m", "onkey"),
+            ("mo", "nkey"),
+            ("mon", "key"),
+            ("monk", "ey"),
+            ("monke", "y"),
+            ("monkey", ""),
         ];
-        let actual = stava.replaces(splits);
-        let expected: Vec<String> = vec![
+        let actual = stava.replaces(&*splits);
+        let expected = vec![
             "aonkey", "bonkey", "conkey", "donkey", "eonkey", "fonkey", "gonkey", "honkey",
             "ionkey", "jonkey", "konkey", "lonkey", "monkey", "nonkey", "oonkey", "ponkey",
             "qonkey", "ronkey", "sonkey", "tonkey", "uonkey", "vonkey", "wonkey", "xonkey",
@@ -280,10 +263,7 @@ mod tests {
             "monkeg", "monkeh", "monkei", "monkej", "monkek", "monkel", "monkem", "monken",
             "monkeo", "monkep", "monkeq", "monker", "monkes", "monket", "monkeu", "monkev",
             "monkew", "monkex", "monkey", "monkez",
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect();
+        ];
         assert_eq!(actual, expected);
     }
 
@@ -292,17 +272,17 @@ mod tests {
         let stava = Stava {
             words_w_count: HashMap::new(),
         };
-        let splits: Vec<(String, String)> = vec![
-            (String::from(""), String::from("monkey")),
-            (String::from("m"), String::from("onkey")),
-            (String::from("mo"), String::from("nkey")),
-            (String::from("mon"), String::from("key")),
-            (String::from("monk"), String::from("ey")),
-            (String::from("monke"), String::from("y")),
-            (String::from("monkey"), String::from("")),
+        let splits = vec![
+            ("", "monkey"),
+            ("m", "onkey"),
+            ("mo", "nkey"),
+            ("mon", "key"),
+            ("monk", "ey"),
+            ("monke", "y"),
+            ("monkey", ""),
         ];
-        let actual = stava.inserts(splits);
-        let expected: Vec<String> = vec![
+        let actual = stava.inserts(&*splits);
+        let expected = vec![
             "amonkey", "bmonkey", "cmonkey", "dmonkey", "emonkey", "fmonkey", "gmonkey", "hmonkey",
             "imonkey", "jmonkey", "kmonkey", "lmonkey", "mmonkey", "nmonkey", "omonkey", "pmonkey",
             "qmonkey", "rmonkey", "smonkey", "tmonkey", "umonkey", "vmonkey", "wmonkey", "xmonkey",
@@ -326,10 +306,7 @@ mod tests {
             "monkeye", "monkeyf", "monkeyg", "monkeyh", "monkeyi", "monkeyj", "monkeyk", "monkeyl",
             "monkeym", "monkeyn", "monkeyo", "monkeyp", "monkeyq", "monkeyr", "monkeys", "monkeyt",
             "monkeyu", "monkeyv", "monkeyw", "monkeyx", "monkeyy", "monkeyz",
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect();
+        ];
         assert_eq!(actual, expected);
     }
 


### PR DESCRIPTION
* Where applicable, use &str over String
* This resulted in a speed improvement for long words, see benchmark
  below

❯ hyperfine 'stava quintessentialquintessentialquintessentialquintessential' -m 10 -n "before optimization"
Benchmark #1: before optimization
  Time (mean ± σ):      6.174 s ±  0.225 s    [User: 6.119 s, System: 0.021 s]
  Range (min … max):    5.849 s …  6.536 s    10 runs

❯ hyperfine 'stava quintessentialquintessentialquintessentialquintessential' -m 10 -n "after optimization"
Benchmark #1: after optimization
  Time (mean ± σ):      3.580 s ±  0.109 s    [User: 3.560 s, System: 0.014 s]
  Range (min … max):    3.482 s …  3.782 s    10 runs